### PR TITLE
BSM Writing Fix

### DIFF
--- a/Better Spectator Mod v1.modinfo
+++ b/Better Spectator Mod v1.modinfo
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Mod id="c6e5ad32-0600-4a98-a7cd-5854a1abcaaf" version="121">
+<Mod id="c6e5ad32-0600-4a98-a7cd-5854a1abcaaf" version="123">
     <Properties>
         <Name>LOC_BSM_TITLE</Name>
         <Description>Allows to play as an Observer. [NEWLINE]In the lobby players in the top 4 slots can choose the Spectator leader. [NEWLINE] In game use the diplomacy ribbon to click on leader and gain their POV and more.
         </Description>
         <Created>1</Created>
         <Teaser>LOC_BSM_TEASER</Teaser>
-        <Authors>D. / Jack The Narrator</Authors>
+        <Authors>D. / Jack The Narrator, FlashyFeeds</Authors>
         <SpecialThanks>Civfanatics.com, CPL, Gedemon, Sukritact, Zur13, Je, DELUXEPhilipe, Malm, Michael</SpecialThanks>
         <CompatibleVersions>1.2,2.0</CompatibleVersions>
-        <Version>121</Version>
+        <Version>123</Version>
     </Properties>
 
     <LocalizedText>
         <Text id="LOC_BSM_TITLE">
-            <en_US>Better Spectator Mod v1.2.1</en_US>
-            <fr_FR>Better Spectator Mod v1.2.1</fr_FR>
+            <en_US>Better Spectator Mod v1.2.3</en_US>
+            <fr_FR>Better Spectator Mod v1.2.3</fr_FR>
         </Text>
         <Text id="LOC_BSM_TEASER">
             <en_US>Allows to play as an Observer</en_US>
@@ -75,6 +75,12 @@
             <File>SPECTATOR_Religious.sql</File>
         </UpdateDatabase>
 
+        <UpdateDatabase id = "WritingBoostFix">
+            <Properties>
+                <LoadOrder>9999</LoadOrder>
+            </Properties>
+            <File>Data/Spectator.sql</File>
+        </UpdateDatabase>
 
         <AddUserInterfaces>
             <Properties>
@@ -161,6 +167,13 @@
                 <LuaReplace>UI/Replacements/worldinput_spec.lua</LuaReplace>
             </Properties>
         </ReplaceUIScript>
+
+        <ImportFiles id="Spectator_UI_events">
+            <Properties>
+                <LoadOrder>9999</LoadOrder>
+            </Properties>
+            <File>UI/Spectator_UI.lua</File>
+        </ImportFiles>
 
         <ImportFiles id="Spectator_ToolTipHelper_PlayerYields">
             <Properties>
@@ -285,6 +298,8 @@
         <File>UI/Replacements/unitpanel_spec.lua</File>
         <File>UI/Replacements/worldinput_spec.lua</File>
         <File>UI/Replacements/worldtracker.lua</File>
+
+        <File>Data/Spectator.sql</File>
 
         <File>Configuration/Config.xml</File>
         <File>Configuration/Config_Beta.xml</File>

--- a/Data/Spectator.sql
+++ b/Data/Spectator.sql
@@ -1,0 +1,9 @@
+UPDATE Boosts SET Unit1Type = NULL, BoostClass = 'BOOST_TRIGGER_NONE_LATE_GAME_CRITICAL_TECH' WHERE TechnologyType = 'TECH_WRITING';
+
+INSERT INTO Modifiers(ModifierId, ModifierType) VALUES
+	('BSM_WRITING_BOOST', 'MODIFIER_PLAYER_GRANT_SPECIFIC_TECH_BOOST');
+
+UPDATE Modifiers SET RunOnce = "1", Permanent = "1" WHERE ModifierId = 'BSM_WRITING_BOOST';
+
+INSERT INTO ModifierArguments(ModifierId, Name, Value) VALUES
+	('BSM_WRITING_BOOST', 'TechType', 'TECH_WRITING');


### PR DESCRIPTION
Spectators cannot give/receive writing boost.
All bugs fixed with writing boost fixed
Version is stable and tested by me and 3 other people in different scenarios.
Spectator FFA and teamers work as normal

Has some print statements for debug in case there are problems.